### PR TITLE
feat: ignore errors about jupyter's display() function

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ inputs:
     default: false
 runs:
   using: 'docker'
-  image: 'docker://mhitza/flake8-jupyter-notebook-github-action:v1'
+  image: 'Dockerfile'

--- a/annotate
+++ b/annotate
@@ -94,6 +94,13 @@ for(let notebook_path of find_notebook_files('.')) {
       return;
     }
 
+    if (error_information[4] === 'F821' && error_information[5].match(/display/)) {
+      // don't report on F821 undefined name 'display'
+      // as display is a builtin function in Jupyter Notebooks
+      // and flake8 doesn't like it
+      return;
+    }
+
     // 4 is the indentation level of embeded source code, +1 for the quote character
     let column        = error_information[3] + 5;
     let error_message = `${error_information[4]} ${error_information[5]}`;

--- a/annotate
+++ b/annotate
@@ -94,7 +94,7 @@ for(let notebook_path of find_notebook_files('.')) {
       return;
     }
 
-    if (error_information[4] === 'F821' && error_information[5].match(/display/)) {
+    if (error_information[4] === 'F821' && error_information[5].includes("'display'")) {
       // don't report on F821 undefined name 'display'
       // as display is a builtin function in Jupyter Notebooks
       // and flake8 doesn't like it


### PR DESCRIPTION
Basically flake8 seems not to know about Jupyter's built in pretty print function `display()` and so throws a wobbly. As I use `display()` a lot for pandas dataframes and such it was getting quite annoying. I believe this will just ignore any F821's with the word "display" in the message.