### PR TITLE
Support ignored paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 A container and a wrapper script around [flake8][1] to validate python code within Jupyter
-notebooks.
+notebooks. flake8 will pick up configuration files in your project, but [some options are not supported](#flake8-configuration-support) and
+will cause the action to fail (sommetimes silently).
 
 
 ## Motivation
@@ -18,6 +19,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: mhitza/flake8-jupyter-notebook@v1
+      with:
+        debug: 'false' # set 'true' for additional logging
+        # paths and files to ignore, one regexp rule per line
+        ignore: |
+          tests/
+          test\.ipynb$
 ```
 
 ![annotation-screenshot]
@@ -60,6 +67,17 @@ necessarily exhaustive and might change based on testing and issues raised.
  - [F821 Undefined name name][F821]. When the undefined name stands for the Jupyter builtin function
    `display`
 
+
+
+### flake8 configuration support
+
+The following options which can be defined in a flake8 configuration file are not supported.
+
+Any option that changes the output of flake8: `--quiet`, `--count`, `--format` (only default supported),
+`--show-source`, `--statistics`.
+
+Anything that relies on filename/paths, as code is passed in to flake8 via stdin.
+Thus the following options will have no effect: `--exclude`, `--extend-exclude`, `--filename`, `--per-file-ignores`
 
 
 [1]: https://flake8.pycqa.org/en/latest/

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     required: false
     description: Dump debug information
     default: false
+  ignore:
+    required: false
+    description: RegExp rules (one per line) for filepaths to exclude
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/mhitza/flake8-jupyter-notebook-github-action:v1'

--- a/annotate
+++ b/annotate
@@ -14,8 +14,23 @@ let cached_processing = {};
 
 const debug = process.env.INPUT_DEBUG === 'true';
 
+const ignore_rules = process.env.INPUT_IGNORE;
+
+let ignore_regexs = [];
+if (ignore_rules !== undefined && ignore_rules.trim() !== "") {
+  ignore_regexs = ignore_rules.trim().split("\n").map(e => new RegExp(e));
+}
 
 for(let notebook_path of find_notebook_files('.')) {
+  if (ignore_regexs.some(re => re.test(notebook_path))) {
+    if (debug) {
+      process.stdout.write(notebook_path + " ignored via regexp rule\n");
+    }
+
+    continue;
+  }
+
+
   if (debug) {
     process.stdout.write(notebook_path + "\n");
   }
@@ -25,7 +40,7 @@ for(let notebook_path of find_notebook_files('.')) {
 
   let source_blocks = find_source_blocks(notebook_lines);
 
-  let extracted_source_code = source_blocks
+  let transformed_source_blocks = source_blocks
 
     .map(({ source_line, lines_of_code }) => { // returns array of formatted lines; ready to join()
 
@@ -44,8 +59,14 @@ for(let notebook_path of find_notebook_files('.')) {
             .replace(/\\n/g, "\n")
             .replace(/\\"/g, '"');
         });
-    })
+    });
 
+  if (transformed_source_blocks.length === 0) {
+    process.stdout.write(notebook_path + " skipped, as it's either an empty file or unparsable!\n");
+    continue;
+  }
+
+  const extracted_source_code = transformed_source_blocks
     .reduce((accumulator, current) => { // without initial value accumulator is first value of array
       return accumulator.concat(current);
     });
@@ -123,8 +144,10 @@ function* find_notebook_files(directory_path) {
   let entry;
   while ((entry = directory.readSync()) !== null) {
     if (entry.isFile()) {
-      if (entry.name.match(/.ipynb$/)) {
-        yield directory_path + '/' + entry.name;
+      const filename = entry.name;
+      const path = directory_path + '/' + filename;
+      if (filename.match(/.ipynb$/)) {
+        yield path;
       }
     }
 

--- a/test-action-locally.sh
+++ b/test-action-locally.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+docker build -t test-action-locally .
+
+which sestatus > /dev/null
+
+seflag=""
+if [ $? -eq 0 ]; then
+  seflag=":z"
+fi
+
+ignore='
+unmatched
+empty.ipynb
+'
+
+docker run --volume "$PWD:$PWD$seflag" --workdir $PWD --env INPUT_DEBUG='true' --env INPUT_IGNORE="$ignore" test-action-locally


### PR DESCRIPTION
Resolves #4 and clarifies #5 

---

While the underlying flake8 call is able to load configuration files, with all their options, due to the fact that code blocks are passed in via stdin certain options (such as exclude flags) do not work, as there is no filename to match on. As a way to work around that specific issue, the action now accepts a separate input field `ignore` in which users can specify via regular expressions their rules.


For a moment it seemed that the `--stdin-display-name` flag could be used to notify flake8 about what file's content was passed via stdin. When testing this flag flake8 was not conforming to the [exclude config docs](https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-exclude). The following two configs should have flake8 perform the same way.

```ini
[flake8]
exclude = directory
```

```ini
[flake8]
exclude = directory/*
```

Only the second configuration format works when invoked in the following manner `cat test.py| flake8 --stdin-display-name=directory/test.py -`